### PR TITLE
Fix multipage zoom issue

### DIFF
--- a/files/CanvasViewer.js
+++ b/files/CanvasViewer.js
@@ -186,6 +186,7 @@ angular.module('CanvasViewer', []).directive('canvasViewer', ['$window', '$http'
           } else {
             if (reader.refresh != null) {
               reader.refresh();
+              scope.resizeTo(scope.options.controls.fit);
             }
           }
         }


### PR DESCRIPTION
When displaying multipage documents, the reader zooms in to fit the first page.
If the page is small, it causes all other pages to be cropped.
The fix resets the zoom level on page change.
It only works with filmstrip mode off.